### PR TITLE
Perf/v1.15 edg/mtu optimization

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -459,6 +459,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		bwManager:            params.BandwidthManager,
 	}
 
+	setMSSForNodeCIDR(params.LocalNodeStore, d.mtuConfig.GetRouteMTU())
+
 	d.configModifyQueue = eventqueue.NewEventQueueBuffered("config-modify-queue", ConfigModifyQueueSize)
 	d.configModifyQueue.Run()
 

--- a/pkg/mtu/mtu.go
+++ b/pkg/mtu/mtu.go
@@ -169,6 +169,9 @@ func (c *Configuration) GetRoutePostEncryptMTU() int {
 // encryption overhead accounted for.
 func (c *Configuration) GetRouteMTU() int {
 	if c.wireguardEnabled {
+		if c.encapEnabled {
+			return c.GetDeviceMTU() - (WireguardOverhead + TunnelOverhead)
+		}
 		return c.GetDeviceMTU() - WireguardOverhead
 	}
 

--- a/pkg/mtu/mtu_test.go
+++ b/pkg/mtu/mtu_test.go
@@ -75,7 +75,7 @@ func (m *MTUSuite) TestNewConfiguration(c *C) {
 
 	conf = NewConfiguration(32, false, true, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
-	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-WireguardOverhead)
+	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(WireguardOverhead+TunnelOverhead))
 
 	testIP1 := net.IPv4(0, 0, 0, 0)
 	testIP2 := net.IPv4(127, 0, 0, 1)


### PR DESCRIPTION
* Account for tunnel overhead in route mtu
* Set MSS on node routes to side step mtu issue for node to node communication (the issue being that one cannot lower the eth0 mtu since the packet goes eth0 -> cilium_wg0 -> eth0. Therefore changing the devices' mtu does not fix the issue)